### PR TITLE
docs: replacing devnet URL from old version link to new version link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 ## 参考
 
-- [kintone JavaScript Client (@kintone/rest-api-client) – cybozu developer network](https://developer.cybozu.io/hc/ja/articles/900000767263)
+- [kintone JavaScript Client (@kintone/rest-api-client) – cybozu developer network](https://cybozu.dev/ja/kintone/sdk/rest-api-client/kintone-javascript-client)


### PR DESCRIPTION
The new devnet will be released on February, and devnet url will be changed.

| old | new |
| ---| --- |
| https://developer.cybozu.io/ | https://cybozu.dev/ |